### PR TITLE
return the figure and axes instead of pyplot module Edit plot function, return figure and axes instead of pyplot module

### DIFF
--- a/waterfall_chart.py
+++ b/waterfall_chart.py
@@ -160,4 +160,4 @@ def plot(index, data, Title="", x_lab="", y_lab="",
     plt.title(Title)
     plt.tight_layout()
 
-    return plt
+    return fig, ax


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18221871/46260788-101f2480-c51d-11e8-8e9e-a0f9c06f2455.png)
Thank you for creating this library. 

The current package return pyplot module from the plot() function, also the pip package was a bit lag behind. I was looking for figsize option, and when I clone the repo I found that it exist in the repo version but not the pip version. 